### PR TITLE
error on pcall return value handling

### DIFF
--- a/AIEN.lua
+++ b/AIEN.lua
@@ -4600,8 +4600,12 @@ local function pcallGetCategory(obj) -- done to avoid DCS errors
             return nil 
         end
     end
-    local res = pcall(effectiveCheck, obj)
-    return res
+    local noError, errorOrResult = pcall(effectiveCheck, obj)
+    if noError then
+        return errorOrResult
+    else
+        env.info(string.format("AIEN pcallGetCategory, error returned when calling the function: %s", errorOrResult or ""))
+    end
 end
 
 -- desanitized functions (if available), for logging, table printing and debug purposes


### PR DESCRIPTION
Fixes issue #16
The pcall in pcallGetCategory returns a boolean and the result of the called function. The existing code returns the boolean to the caller.
