### PR TITLE
Update AIEN.lua

### DIFF
--- a/AIEN.lua
+++ b/AIEN.lua
@@ -9385,8 +9385,8 @@ local function event_hit(unit, shooter, weapon) -- this functions run eacht time
                                     if AIEN.config.AIEN_debugProcessDetail == true then
                                         env.info(("AIEN.event_hit, S_EVENT_HIT, shooter is airborne, removing less sensed decision"))
                                     end	                                  
-                                    av_ac[5] = nil -- remove attack
-                                    av_ac[7] = nil -- remove ground support
+                                    av_ac[6] = nil -- remove attack
+                                    av_ac[8] = nil -- remove ground support
                                     av_ac[3] = nil -- remove disperse
                                 end
                                 if s_cls ~= "ARBN" then -- shooter is not airborne


### PR DESCRIPTION
Fixed Event_hit function where AV_AC numbers were off.

## Summary by Sourcery

Fix incorrect AV_AC index assignments in the event_hit function to properly remove attack and ground support decisions.

Bug Fixes:
- Corrected AV_AC indices from 5 to 6 for attack removal.
- Corrected AV_AC indices from 7 to 8 for ground support removal.